### PR TITLE
enable specification of Rt estimation window length

### DIFF
--- a/R/estimate_R_cl.R
+++ b/R/estimate_R_cl.R
@@ -34,6 +34,7 @@ estimate_R_cl <- function(
   ),
   prm.R = list(
     iter = 10,
+    window = 7,
     config.EpiEstim = NULL
   )
 ) {

--- a/R/estimate_R_cl_rep.R
+++ b/R/estimate_R_cl_rep.R
@@ -11,10 +11,8 @@ estimate_R_cl_rep <- function(
     dist.repdelay,
     dist.incub,
     dist.gi,
-    prm.R = list(
-      iter = 100,
-      config.EpiEstim = NULL
-    )) {
+    prm.R
+){
 
   if(is.null(prm.R$config.EpiEstim)) message("Using default config in `EpiEstim::estimate_R()`.")
 

--- a/R/estimate_R_cl_single.R
+++ b/R/estimate_R_cl_single.R
@@ -5,11 +5,7 @@
 #' @param dist.repdelay parameters for the reporting delay distribution
 #' @param dist.incub parameters for the incubation period distribution
 #' @param dist.gi parameters for the generation interval distribution
-#' @param prm.R list. settings for the ensemble when calculating Rt. elements include:
-#' \itemize{
-#'  \item{`iter`: }{number of iterations for ensemble}
-#'  \item{`config.EpiEstim`: }{configuration for `EpiEstim` defined via `EpiEstim::make_config()`. if `NULL`, will use default config from `EpiEstim`.}
-#' }
+#' @inheritParams incidence_to_R
 #'
 #' @importFrom rlang .data
 #'
@@ -68,7 +64,7 @@ estimate_R_cl_single <- function(
   (incidence_to_R(
     incidence,
     generation.interval,
-    config.EpiEstim = prm.R$config.EpiEstim
+    prm.R
   )
     %>% dplyr::transmute(
       .data$date,

--- a/R/incidence_to_R.R
+++ b/R/incidence_to_R.R
@@ -2,7 +2,12 @@
 #'
 #' @param incidence dataframe. estimated incidence. includes at least `date`, `I`, and `t` columns.
 #' @param generation.interval list. parameters for generation interval from [`def_dist_generation_interval()`].
-#' @param config.EpiEstim configuration for `EpiEstim` defined via `EpiEstim::make_config()`. if `NULL`, use default config from `EpiEstim`.
+#' @param prm.R list. settings for the ensemble when calculating Rt. elements include:
+#' \itemize{
+#'  \item{`iter`: }{number of iterations for ensemble}
+#'  \item{`window`: }{length of time window to use for each Rt estimate. if `t_end` is specified in `config.EpiEstim`, this option will override it.}
+#'  \item{`config.EpiEstim`: }{configuration for `EpiEstim` defined via `EpiEstim::make_config()`. if `NULL`, will use default config from `EpiEstim`.}
+#' }
 #'
 #' @importFrom rlang .data
 #'
@@ -11,13 +16,15 @@
 incidence_to_R <- function(
     incidence,
     generation.interval,
-    config.EpiEstim = NULL
+    prm.R
 ){
   # prep inputs
   # -------------------------
+
+  # make config
   incid <- incidence$I
   method <- "si_from_sample"
-  if(is.null(config.EpiEstim)){
+  if(is.null(prm.R$config.EpiEstim)){
     config.EpiEstim <- suppressMessages(EpiEstim::make_config(
       incid = incid,
       method = method
@@ -26,8 +33,20 @@ incidence_to_R <- function(
     config.EpiEstim <- suppressMessages(EpiEstim::make_config(
       incid = incid,
       method = method,
-      config = config.EpiEstim
+      config = prm.R$config.EpiEstim
     ))
+  }
+
+  # update t_end in config if window is specified in prm.R
+  # NOTE: this overrides specification of t_end in config.EpiEstim
+  if(!is.null(prm.R$window)){
+    t_start <- config.EpiEstim$t_start
+    t_end <- as.integer(t_start + (prm.R$window - 1)) # -1 because window includes endpoints
+    # trim off start/end dates where end date exceeds
+    # number of incidence observations
+    valid <- t_end <= length(incid)
+    config.EpiEstim$t_start <- t_start[valid]
+    config.EpiEstim$t_end <- t_end[valid]
   }
 
   # calculate Rt based on _one_ generation interval

--- a/dev/cl-test-script.R
+++ b/dev/cl-test-script.R
@@ -25,10 +25,11 @@ prm.daily = list(
   iter = 30,
   chains = 2
 )
-prm.smooth = list( window = 7)
+prm.smooth = list(window = 7)
 prm.R = list(
-  iter = 2
-  , config.EpiEstim = EpiEstim::make_config(
+  iter = 2,
+  # window = 10, # if window isn't specified, assume 7 day est window for Rt
+  config.EpiEstim = EpiEstim::make_config(
     seed = 14
   )
 )


### PR DESCRIPTION
if `window` isn't specified in `prm.R`, assume 7 day window (EpiEstim default)

fixes #51