### PR TITLE
Jags

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Suggests:
     rmarkdown,
     bookdown,
     purrr,
+    runjags,
     testthat (>= 3.0.0)
 VignetteBuilder: 
     knitr

--- a/R/estimate_R_cl.R
+++ b/R/estimate_R_cl.R
@@ -67,6 +67,15 @@ estimate_R_cl <- function(
   silent = FALSE
 ) {
 
+  # Checking if JAGS is installed on machine. Stop function if not found
+  suppressWarnings(j <- runjags::testjags(silent = TRUE))
+  if(isFALSE(j$JAGS.found)){
+stop("JAGS is not installed on this machine.
+Please install JAGS on https://sourceforge.net/projects/mcmc-jags/files/
+or request JAGS to be installed by your network administrator
+before loading package.")
+  }
+
   # Checking arguments
   check_prm.R(prm.R, silent = silent)
   check_data_clin(cl.agg, silent = silent)

--- a/R/estimate_R_cl.R
+++ b/R/estimate_R_cl.R
@@ -70,10 +70,10 @@ estimate_R_cl <- function(
   # Checking if JAGS is installed on machine. Stop function if not found
   suppressWarnings(j <- runjags::testjags(silent = TRUE))
   if(isFALSE(j$JAGS.found)){
-stop("JAGS is not installed on this machine.
-Please install JAGS on https://sourceforge.net/projects/mcmc-jags/files/
-or request JAGS to be installed by your network administrator
-before loading package.")
+stop("JAGS is not installed on this machine but is required for Rt calculations on clinical testing data using ern::estimate_Rt_cl().
+To use this functionality, please install JAGS on https://sourceforge.net/projects/mcmc-jags/files/
+or request JAGS to be installed by your network administrator.
+See README for more details.")
   }
 
   # Checking arguments

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,8 +1,8 @@
 .onAttach <- function(libname, pkgname){
   suppressWarnings(j <- runjags::testjags(silent = TRUE))
   if(isFALSE(j$JAGS.found)){
-    warning("JAGS is not installed on this machine.
-Please install JAGS on https://sourceforge.net/projects/mcmc-jags/files/
+    warning("JAGS is not installed on this machine but is required for Rt calculations on clinical testing data using ern::estimate_Rt_cl().
+To use this functionality, please install JAGS on https://sourceforge.net/projects/mcmc-jags/files/
 or request JAGS to be installed by your network administrator.
 See README for more details.")
   }
@@ -15,8 +15,8 @@ See README for more details.")
 .onLoad <- function(libname, pkgname){
   suppressWarnings(j <- runjags::testjags(silent = TRUE))
   if(isFALSE(j$JAGS.found)){
-    warning("JAGS is not installed on this machine.
-Please install JAGS on https://sourceforge.net/projects/mcmc-jags/files/
+    warning("JAGS is not installed on this machine but is required for Rt calculations on clinical testing data using ern::estimate_Rt_cl().
+To use this functionality, please install JAGS on https://sourceforge.net/projects/mcmc-jags/files/
 or request JAGS to be installed by your network administrator.
 See README for more details.")
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,14 @@
+.onLoad <- function(libname, pkgname){
+  j = runjags::testjags(silent = TRUE)
+  if(is.null(j)){
+    stop("JAGS is not installed on this machine.
+Please install JAGS on https://sourceforge.net/projects/mcmc-jags/files/
+or request JAGS to be installed by your network administrator
+before loading package.")
+  }
+  else{
+    message(
+    paste("JAGS version", j$JAGS.version, "installed.\nrjags version", j$rjags.version, "installed."))
+
+  }
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,10 +1,10 @@
 .onAttach <- function(libname, pkgname){
   suppressWarnings(j <- runjags::testjags(silent = TRUE))
   if(isFALSE(j$JAGS.found)){
-    stop("JAGS is not installed on this machine.
+    warning("JAGS is not installed on this machine.
 Please install JAGS on https://sourceforge.net/projects/mcmc-jags/files/
-or request JAGS to be installed by your network administrator
-before loading package.")
+or request JAGS to be installed by your network administrator.
+See README for more details.")
   }
   else if(isTRUE(j$JAGS.found)){
     packageStartupMessage(
@@ -15,9 +15,9 @@ before loading package.")
 .onLoad <- function(libname, pkgname){
   suppressWarnings(j <- runjags::testjags(silent = TRUE))
   if(isFALSE(j$JAGS.found)){
-    stop("JAGS is not installed on this machine.
+    warning("JAGS is not installed on this machine.
 Please install JAGS on https://sourceforge.net/projects/mcmc-jags/files/
-or request JAGS to be installed by your network administrator
-before loading package.")
+or request JAGS to be installed by your network administrator.
+See README for more details.")
   }
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,14 +1,13 @@
-.onLoad <- function(libname, pkgname){
-  j = runjags::testjags(silent = TRUE)
-  if(is.null(j)){
+.onAttach <- function(libname, pkgname){
+  suppressWarnings(j <- runjags::testjags(silent = TRUE))
+  if(isFALSE(j$JAGS.found)){
     stop("JAGS is not installed on this machine.
 Please install JAGS on https://sourceforge.net/projects/mcmc-jags/files/
 or request JAGS to be installed by your network administrator
 before loading package.")
   }
-  else{
-    message(
+  else if(isTRUE(j$JAGS.found)){
+    packageStartupMessage(
     paste("JAGS version", j$JAGS.version, "installed.\nrjags version", j$rjags.version, "installed."))
-
   }
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -11,3 +11,13 @@ before loading package.")
     paste("JAGS version", j$JAGS.version, "installed.\nrjags version", j$rjags.version, "installed."))
   }
 }
+
+.onLoad <- function(libname, pkgname){
+  suppressWarnings(j <- runjags::testjags(silent = TRUE))
+  if(isFALSE(j$JAGS.found)){
+    stop("JAGS is not installed on this machine.
+Please install JAGS on https://sourceforge.net/projects/mcmc-jags/files/
+or request JAGS to be installed by your network administrator
+before loading package.")
+  }
+}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ devtools::install_github('phac-nml-phrsd/ern')
 
 `rjags` is a dependency for `ern`. `rjags` is the R interface for the [`JAGS` Bayesian modelling library](https://mcmc-jags.sourceforge.io/). Installation of `JAGS` is required and the latest version can be found [here](https://sourceforge.net/projects/mcmc-jags/files/). It is recommended that you are using the latest version of R and `JAGS` for optimal usage of `ern`.
 
-* For users who are only able to install older versions of `JAGS`, we recommend downgrading to R version 4.1.
+* For users who are only unable to install the latest version of `JAGS`, we recommend downgrading to an R version that is less than 4.2. More details can be found [here](https://martynplummer.wordpress.com/2022/04/12/windows-update-jags-4-3-1-is-released/)
+* For users who are having issues installing or running `JAGS` or `rjags`, we recommend using the [`JAGS` discussion board](https://sourceforge.net/p/mcmc-jags/discussion/610037/). 
 
 ## Vignettes
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ devtools::install_github('phac-nml-phrsd/ern')
 
 ### Note on JAGS
 
-`rjags` is a dependency for `ern`. `rjags` is the R interface for the [`JAGS` Bayesian modelling library](https://mcmc-jags.sourceforge.io/). Installation of `JAGS` is required and the latest version can be found [here](https://sourceforge.net/projects/mcmc-jags/files/). It is recommended that you are using the latest version of R and `JAGS` for optimal usage of `ern`.
+`rjags` is a dependency for `ern`, specifically for Rt calculations performed on clinical testing data. `rjags` is the R interface for the [`JAGS` Bayesian modelling library](https://mcmc-jags.sourceforge.io/). Installation of `JAGS` is required and the latest version can be found [here](https://sourceforge.net/projects/mcmc-jags/files/). It is recommended that you are using the latest version of R and `JAGS` for optimal usage of `ern`.
 
 * For users who are only unable to install the latest version of `JAGS`, we recommend downgrading to an R version that is less than 4.2. More details can be found [here](https://martynplummer.wordpress.com/2022/04/12/windows-update-jags-4-3-1-is-released/)
-* For users who are having issues installing or running `JAGS` or `rjags`, we recommend using the [`JAGS` discussion board](https://sourceforge.net/p/mcmc-jags/discussion/610037/). 
+* For users who are having issues installing or running `JAGS` or `rjags`, we recommend consulting the [`JAGS` discussion board](https://sourceforge.net/p/mcmc-jags/discussion/610037/). 
 
 ## Vignettes
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ To install the latest version of this package:
 devtools::install_github('phac-nml-phrsd/ern')
 ```
 
+### Note on JAGS
+
+`rjags` is a dependency for `ern`. `rjags` is the R interface for the [`JAGS` Bayesian modelling library](https://mcmc-jags.sourceforge.io/). Installation of `JAGS` is required and the latest version can be found [here](https://sourceforge.net/projects/mcmc-jags/files/). It is recommended that you are using the latest version of R and `JAGS` for optimal usage of `ern`.
+
+* For users who are only able to install older versions of `JAGS`, we recommend downgrading to R version 4.1.
+
 ## Vignettes
 
 This package contains vignettes on how `ern` can be used to estimate $R_t$. 


### PR DESCRIPTION
**1. Provide documentation in `README` about having JAGS installed on machine, and what to do if users cannot install latest version of JAGS (due to network restrictions).**

**2. Provide output messages for JAGS status on machine as per #18.**

When user has JAGS installed, the following output message is shown when calling package to the global environment.
   ```r 
    library(ern)
    JAGS version 4.3.1 installed.
    rjags version 4-13 installed.
  ````
When user does not have JAGS installed, the following output message is shown when calling package to the global environment. Error message indicates JAGS is not installed on machine and provides instructions on how to install package.
```r
library(ern)
Error: package or namespace load failed for ‘ern’:
 .onAttach failed in attachNamespace() for 'ern', details:
  call: fun(libname, pkgname)
  error: JAGS is not installed on this machine.
Please install JAGS on https://sourceforge.net/projects/mcmc-jags/files/
or request JAGS to be installed by your network administrator
before loading package.
```
Same error message is shown when user is using an `ern` function without loading package to the global environment (e.g. `ern::estimate_R_cl()`).