### PR TITLE
JAGS messaging

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -12,12 +12,3 @@ See README for more details.")
   }
 }
 
-.onLoad <- function(libname, pkgname){
-  suppressWarnings(j <- runjags::testjags(silent = TRUE))
-  if(isFALSE(j$JAGS.found)){
-    warning("JAGS is not installed on this machine but is required for Rt calculations on clinical testing data using ern::estimate_Rt_cl().
-To use this functionality, please install JAGS on https://sourceforge.net/projects/mcmc-jags/files/
-or request JAGS to be installed by your network administrator.
-See README for more details.")
-  }
-}


### PR DESCRIPTION
Remove .onLoad to prevent duplicate messaging of JAGS presence on user's machine as observed in #18. 

Since `estimate_R_cl()` provides a stop if JAGS is not installed, providing a warning only when a user attaches the package to their environment (i.e. `library(ern)`) may be useful in preventing duplicated messages. 