### PR TITLE
Minimum smoothed concentration

### DIFF
--- a/R/distributions.R
+++ b/R/distributions.R
@@ -208,19 +208,25 @@ def_dist_fecal_shedding <- function(pathogen = 'sarscov2', subtype = '') {
 #' Define a family of reporting delay distributions
 #'
 #' @template return-dist
+#' @template param-pathogen
 #'
 #' @export
-def_dist_reporting_delay <- function(){
-  # for SARS-CoV-2 in Canada
-  # TODO: this is just a dummy distribution, get real thing from linelist
-  list(
-    dist = 'gamma',
-    mean = 5,
-    mean_sd = 1,
-    sd = 1,
-    sd_sd = 0.1,
-    max = 10
-  )
+def_dist_reporting_delay <- function(pathogen = 'sarscov2'){
+  if(!(pathogen %in% c('sarscov2'))){
+    stop(paste0("No default reporting delay distribution for pathogen `", pathogen,"`. Aborting!"))
+  }
+
+  if(pathogen == 'sarscov2'){
+    # TODO: this is just a dummy distribution, get real thing from linelist
+    list(
+      dist = 'gamma',
+      mean = 5,
+      mean_sd = 1,
+      sd = 1,
+      sd_sd = 0.1,
+      max = 10
+    )
+  }
 }
 
 # - - - - - - - - - - - - - - - - -

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -207,6 +207,8 @@ def_dist_fecal_shedding <- function(pathogen = 'sarscov2', subtype = '') {
 
 #' Define a family of reporting delay distributions
 #'
+#' Default values come from analyzing COVID-19 line list data across all of Canada for the time period matching the sample COVID-19 clinical data provided in [ern::cl.agg]
+#'
 #' @template return-dist
 #' @template param-pathogen
 #'
@@ -217,14 +219,13 @@ def_dist_reporting_delay <- function(pathogen = 'sarscov2'){
   }
 
   if(pathogen == 'sarscov2'){
-    # TODO: this is just a dummy distribution, get real thing from linelist
     list(
       dist = 'gamma',
-      mean = 5,
-      mean_sd = 1,
-      sd = 1,
-      sd_sd = 0.1,
-      max = 10
+      mean = 6.99,
+      mean_sd = 0.2211,
+      sd = 3.663,
+      sd_sd = 0.1158,
+      max = 21
     )
   }
 }

--- a/R/globals.R
+++ b/R/globals.R
@@ -6,5 +6,5 @@ utils::globalVariables(c(
   "upr","upr.agg","use","use.cumm","val","val_smooth",
   "value","value_smooth","y",
   "t.diff", "t.diff.check", "check",
-  "silent", "x"
+  "silent", "x", "case_when"
 ))

--- a/R/smooth.R
+++ b/R/smooth.R
@@ -79,7 +79,7 @@ smooth_with_rollmean <- function(df, prm.smooth){
     %>% dplyr::mutate(
       value_smooth = zoo::rollapply(
         value, width = prm.smooth$window,
-        FUN = mean, align = prm.smooth$align,
+        FUN = mean, na.rm = TRUE, align = prm.smooth$align,
         partial = TRUE
     ))
     # standardize output

--- a/R/smooth.R
+++ b/R/smooth.R
@@ -114,10 +114,11 @@ smooth_with_loess <- function(df, prm.smooth) {
     # standardize output
     %>% dplyr::transmute(
       t = x,
-      value_smooth = ifelse(isTRUE(floor),
-                            case_when(y < prm.smooth$floor ~ prm.smooth$floor,
-                                      y >= prm.smooth$floor ~ y),
-                            y),
+      value_smooth = 
+        if(isTRUE(floor))
+          case_when(y < prm.smooth$floor ~ prm.smooth$floor,
+                    y >= prm.smooth$floor ~ y)
+        else y,
       date = lubridate::ymd(min(df$date)) + t
     )
     %>% dplyr::select(

--- a/R/smooth.R
+++ b/R/smooth.R
@@ -104,6 +104,9 @@ smooth_with_loess <- function(df, prm.smooth) {
   # extract time index and fitted values
   t = z$x[,"t"]
   v = z$fitted
+  
+  # determine if concentration floor specified
+  floor = ifelse(!is.null(prm.smooth$floor), TRUE, FALSE)
 
   # interpolate in case of missing values
   d = (stats::approx(x = t, y = v, xout = 1:max(t))
@@ -111,7 +114,10 @@ smooth_with_loess <- function(df, prm.smooth) {
     # standardize output
     %>% dplyr::transmute(
       t = x,
-      value_smooth = y,
+      value_smooth = ifelse(isTRUE(floor),
+                            case_when(y < prm.smooth$floor ~ prm.smooth$floor,
+                                      y >= prm.smooth$floor ~ y),
+                            y),
       date = lubridate::ymd(min(df$date)) + t
     )
     %>% dplyr::select(

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,66 @@
+---
+output: github_document
+---
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "man/figures/README-",
+  out.width = "100%"
+)
+```
+
+# ern
+
+<!-- badges: start -->
+
+[![codecov](https://codecov.io/gh/phac-nml-phrsd/ern/branch/main/graph/badge.svg?token=SWXENVF9T4)](https://codecov.io/gh/phac-nml-phrsd/ern) [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+
+<!-- badges: end -->
+
+This repository stores the code used in `ern`, an R package to estimate the effective reproduction number ($R_t$) of pathogens using clinical or wastewater data.
+
+This package is developed at the Public Health Agency of Canada / National Microbiology Laboratory. Please note this software is provivded "as is", without warranty of any kind; see the [license](LICENSE).
+
+## Installation
+
+To install the latest version of this package:
+
+```r
+devtools::install_github('phac-nml-phrsd/ern')
+```
+
+### Note on JAGS
+
+`rjags` is a dependency for `ern`, specifically for Rt calculations performed on clinical testing data. If you are only performing calculations using wastewater data, you do not need to worry about installing `rjags` and can skip this section.
+
+`rjags` is the R interface for the [`JAGS` Bayesian modelling library](https://mcmc-jags.sourceforge.io/). Installation of `JAGS` is required and the latest version can be found [here](https://sourceforge.net/projects/mcmc-jags/files/). It is recommended that you are using the latest version of R and `JAGS` for optimal usage of `ern`.
+
+* For users who are only unable to install the latest version of `JAGS`, we recommend downgrading to an R version that is less than 4.2. More details can be found [here](https://martynplummer.wordpress.com/2022/04/12/windows-update-jags-4-3-1-is-released/)
+* For users who are having issues installing or running `JAGS` or `rjags`, we recommend consulting the [`JAGS` discussion board](https://sourceforge.net/p/mcmc-jags/discussion/610037/). 
+
+## Vignettes
+
+To use `ern` to estimate $R_t$:
+
+```{r, eval = FALSE}
+vignette("est-rt", package = "ern")
+```
+
+To learn more about how default distribution parameters were estimated in `ern`:
+
+```{r, eval = FALSE}
+vignette("distributions", package = "ern")
+```
+
+## Citation
+
+You can cite `ern` with:
+
+```{r}
+citation('ern')
+```
+

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ citation('ern')
 #>   the Effective Reproduction Number Using Clinical and Wastewater
 #>   Surveillance Data_. National Microbiology Laboratory, Public Health
 #>   Agency of Canada, Government of Canada.
+#>   <https://github.com/phac-nml-phrsd/ern>.
 #> 
 #> A BibTeX entry for LaTeX users is
 #> 
@@ -85,5 +86,6 @@ citation('ern')
 #>     author = {David Champredon and Irena Papst and Warsame Yusuf},
 #>     organization = {National Microbiology Laboratory, Public Health Agency of Canada, Government of Canada},
 #>     year = {2023},
+#>     url = {https://github.com/phac-nml-phrsd/ern},
 #>   }
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ devtools::install_github('phac-nml-phrsd/ern')
 
 ### Note on JAGS
 
-`rjags` is a dependency for `ern`, specifically for Rt calculations performed on clinical testing data. `rjags` is the R interface for the [`JAGS` Bayesian modelling library](https://mcmc-jags.sourceforge.io/). Installation of `JAGS` is required and the latest version can be found [here](https://sourceforge.net/projects/mcmc-jags/files/). It is recommended that you are using the latest version of R and `JAGS` for optimal usage of `ern`.
+`rjags` is a dependency for `ern`, specifically for Rt calculations performed on clinical testing data. If you are only performing calculatings using wastewater data, you do not need to worry about installing `rjags` and can skip this section.
+
+`rjags` is the R interface for the [`JAGS` Bayesian modelling library](https://mcmc-jags.sourceforge.io/). Installation of `JAGS` is required and the latest version can be found [here](https://sourceforge.net/projects/mcmc-jags/files/). It is recommended that you are using the latest version of R and `JAGS` for optimal usage of `ern`.
 
 * For users who are only unable to install the latest version of `JAGS`, we recommend downgrading to an R version that is less than 4.2. More details can be found [here](https://martynplummer.wordpress.com/2022/04/12/windows-update-jags-4-3-1-is-released/)
 * For users who are having issues installing or running `JAGS` or `rjags`, we recommend consulting the [`JAGS` discussion board](https://sourceforge.net/p/mcmc-jags/discussion/610037/). 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,89 @@
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
 # ern
 
 <!-- badges: start -->
 
-[![codecov](https://codecov.io/gh/phac-nml-phrsd/ern/branch/main/graph/badge.svg?token=SWXENVF9T4)](https://codecov.io/gh/phac-nml-phrsd/ern) [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![codecov](https://codecov.io/gh/phac-nml-phrsd/ern/branch/main/graph/badge.svg?token=SWXENVF9T4)](https://codecov.io/gh/phac-nml-phrsd/ern)
+[![Lifecycle:
+experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 
 <!-- badges: end -->
 
-This repository stores the code used in `ern`, an R package to estimate the effective reproduction number ($R_t$) of pathogens using clinical or wastewater data.
+This repository stores the code used in `ern`, an R package to estimate
+the effective reproduction number ($R_t$) of pathogens using clinical or
+wastewater data.
 
-This package is developed at the Public Health Agency of Canada / National Microbiology Laboratory. Please note this software is provivded "as is", without warranty of any kind; see the [license](LICENSE).
+This package is developed at the Public Health Agency of Canada /
+National Microbiology Laboratory. Please note this software is provivded
+“as is”, without warranty of any kind; see the [license](LICENSE).
 
 ## Installation
 
 To install the latest version of this package:
 
-```r
+``` r
 devtools::install_github('phac-nml-phrsd/ern')
 ```
 
 ### Note on JAGS
 
-`rjags` is a dependency for `ern`, specifically for Rt calculations performed on clinical testing data. If you are only performing calculatings using wastewater data, you do not need to worry about installing `rjags` and can skip this section.
+`rjags` is a dependency for `ern`, specifically for Rt calculations
+performed on clinical testing data. If you are only performing
+calculations using wastewater data, you do not need to worry about
+installing `rjags` and can skip this section.
 
-`rjags` is the R interface for the [`JAGS` Bayesian modelling library](https://mcmc-jags.sourceforge.io/). Installation of `JAGS` is required and the latest version can be found [here](https://sourceforge.net/projects/mcmc-jags/files/). It is recommended that you are using the latest version of R and `JAGS` for optimal usage of `ern`.
+`rjags` is the R interface for the [`JAGS` Bayesian modelling
+library](https://mcmc-jags.sourceforge.io/). Installation of `JAGS` is
+required and the latest version can be found
+[here](https://sourceforge.net/projects/mcmc-jags/files/). It is
+recommended that you are using the latest version of R and `JAGS` for
+optimal usage of `ern`.
 
-* For users who are only unable to install the latest version of `JAGS`, we recommend downgrading to an R version that is less than 4.2. More details can be found [here](https://martynplummer.wordpress.com/2022/04/12/windows-update-jags-4-3-1-is-released/)
-* For users who are having issues installing or running `JAGS` or `rjags`, we recommend consulting the [`JAGS` discussion board](https://sourceforge.net/p/mcmc-jags/discussion/610037/). 
+- For users who are only unable to install the latest version of `JAGS`,
+  we recommend downgrading to an R version that is less than 4.2. More
+  details can be found
+  [here](https://martynplummer.wordpress.com/2022/04/12/windows-update-jags-4-3-1-is-released/)
+- For users who are having issues installing or running `JAGS` or
+  `rjags`, we recommend consulting the [`JAGS` discussion
+  board](https://sourceforge.net/p/mcmc-jags/discussion/610037/).
 
 ## Vignettes
 
 To use `ern` to estimate $R_t$:
 
-```r
+``` r
 vignette("est-rt", package = "ern")
 ```
 
-To learn more about how default distribution parameters were estimated in `ern`:
+To learn more about how default distribution parameters were estimated
+in `ern`:
 
-```r
+``` r
 vignette("distributions", package = "ern")
+```
+
+## Citation
+
+You can cite `ern` with:
+
+``` r
+citation('ern')
+#> 
+#> To cite package 'ern' in publications use:
+#> 
+#>   Champredon D, Papst I, Yusuf W (2023). _ern: An R Package to Estimate
+#>   the Effective Reproduction Number Using Clinical and Wastewater
+#>   Surveillance Data_. National Microbiology Laboratory, Public Health
+#>   Agency of Canada, Government of Canada.
+#> 
+#> A BibTeX entry for LaTeX users is
+#> 
+#>   @Manual{,
+#>     title = {ern: An R Package to Estimate the Effective Reproduction Number Using Clinical and Wastewater Surveillance Data},
+#>     author = {David Champredon and Irena Papst and Warsame Yusuf},
+#>     organization = {National Microbiology Laboratory, Public Health Agency of Canada, Government of Canada},
+#>     year = {2023},
+#>   }
 ```

--- a/data-raw/cl-input.R
+++ b/data-raw/cl-input.R
@@ -4,8 +4,7 @@
 pt.list <- c("bc", "ab", "sk", "mb", "on", "qc")
 
 # date horizon of data
-date.lim <- c(lubridate::today() - months(4),
-              lubridate::today())
+date.lim <- as.Date(c("2022-12-24", "2023-04-08"))
 
 # lookup table for provice names
 pt.lookup <- tibble::tribble(

--- a/ern.Rproj
+++ b/ern.Rproj
@@ -1,7 +1,7 @@
 Version: 1.0
 
-RestoreWorkspace: No
-SaveWorkspace: No
+RestoreWorkspace: Default
+SaveWorkspace: Default
 AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
@@ -12,11 +12,6 @@ Encoding: UTF-8
 RnwWeave: Sweave
 LaTeX: pdfLaTeX
 
-AutoAppendNewline: Yes
-StripTrailingWhitespace: Yes
-LineEndingConversion: Posix
-
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
-PackageRoxygenize: rd,collate,namespace

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,5 +3,6 @@ bibentry(
   title    = "ern: An R Package to Estimate the Effective Reproduction Number Using Clinical and Wastewater Surveillance Data",
   author   = "David Champredon, Irena Papst, Warsame Yusuf",
   organization = "National Microbiology Laboratory, Public Health Agency of Canada, Government of Canada",
-  year     = 2023
+  year     = 2023,
+  url = "https://github.com/phac-nml-phrsd/ern"
 )

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,7 @@
+bibentry(
+  bibtype  = "Manual",
+  title    = "ern: An R Package to Estimate the Effective Reproduction Number Using Clinical and Wastewater Surveillance Data",
+  author   = "David Champredon, Irena Papst, Warsame Yusuf",
+  organization = "National Microbiology Laboratory, Public Health Agency of Canada, Government of Canada",
+  year     = 2023
+)

--- a/man-roxygen/param-prm.smooth.R
+++ b/man-roxygen/param-prm.smooth.R
@@ -5,5 +5,6 @@
 #'   \item `window`: for `method = 'rollmean` only; width of smoothing window in days
 #'   \item `align`: for `method = 'rollmean` only; smoothing alignment, either `'center'`, `'left'`, `'right'`
 #'   \item `span`: for `method = 'loess'` only; smoothing span (see the documentation for `stats::loess()` for details)
+#'   \item `floor`: optional call for wastewater concentration smoothing with `method = 'loess'` only; user defined minimum smoothing concentration
 #'  }
 #'  Set this entire list to `NULL` to turn off smoothing

--- a/man/def_dist_reporting_delay.Rd
+++ b/man/def_dist_reporting_delay.Rd
@@ -4,7 +4,10 @@
 \alias{def_dist_reporting_delay}
 \title{Define a family of reporting delay distributions}
 \usage{
-def_dist_reporting_delay()
+def_dist_reporting_delay(pathogen = "sarscov2")
+}
+\arguments{
+\item{pathogen}{String. Name of the pathogen ('sarscov2', 'influenza')}
 }
 \value{
 List with components
@@ -19,5 +22,5 @@ List with components
 }
 }
 \description{
-Define a family of reporting delay distributions
+Default values come from analyzing COVID-19 line list data across all of Canada for the time period matching the sample COVID-19 clinical data provided in \link{cl.agg}
 }

--- a/man/estimate_R_ww.Rd
+++ b/man/estimate_R_ww.Rd
@@ -37,6 +37,7 @@ specified as followed:
 \item \code{window}: for \verb{method = 'rollmean} only; width of smoothing window in days
 \item \code{align}: for \verb{method = 'rollmean} only; smoothing alignment, either \code{'center'}, \code{'left'}, \code{'right'}
 \item \code{span}: for \code{method = 'loess'} only; smoothing span (see the documentation for \code{stats::loess()} for details)
+\item \code{floor}: optional call for wastewater concentration smoothing with \code{method = 'loess'} only; user defined minimum smoothing concentration
 }
 Set this entire list to \code{NULL} to turn off smoothing}
 

--- a/man/smooth_ww.Rd
+++ b/man/smooth_ww.Rd
@@ -20,6 +20,7 @@ specified as followed:
 \item \code{window}: for \verb{method = 'rollmean} only; width of smoothing window in days
 \item \code{align}: for \verb{method = 'rollmean} only; smoothing alignment, either \code{'center'}, \code{'left'}, \code{'right'}
 \item \code{span}: for \code{method = 'loess'} only; smoothing span (see the documentation for \code{stats::loess()} for details)
+\item \code{floor}: optional call for wastewater concentration smoothing with \code{method = 'loess'} only; user defined minimum smoothing concentration
 }
 Set this entire list to \code{NULL} to turn off smoothing}
 

--- a/vignettes/est-rt.Rmd
+++ b/vignettes/est-rt.Rmd
@@ -143,7 +143,7 @@ prm.smooth = list(
   align  = 'center', # smoothing alignment
   method = 'loess',  # smoothing method
   span   = 0.29,     # smoothing span (used for loess smoothing only)
-  floor  = 5,         # minimum smoothed concentration value (optional, loess smoothing only)
+  floor  = 5         # minimum smoothed concentration value (optional, loess smoothing only)
 )
 
 # Initialzing Rt settings

--- a/vignettes/est-rt.Rmd
+++ b/vignettes/est-rt.Rmd
@@ -142,7 +142,8 @@ scaling.factor = 1
 prm.smooth = list(
   align  = 'center', # smoothing alignment
   method = 'loess',  # smoothing method
-  span   = 0.29      # smoothing span (used for loess smoothing only)
+  span   = 0.29,     # smoothing span (used for loess smoothing only)
+  floor  = 5,         # minimum smoothed concentration value (optional, loess smoothing only)
 )
 
 # Initialzing Rt settings


### PR DESCRIPTION
- Addresses #162 
- Users can set a floor in `prm.smooth` that acts as the minimum concentration value when smoothing raw wastewater data.
- Floor is optional. If unspecified, minimum smoothed concentration will be based on the output of LOESS smoothing.