### PR TITLE
heuristic fix to initial high clinical Rt

### DIFF
--- a/R/estimate_R_cl_single.R
+++ b/R/estimate_R_cl_single.R
@@ -55,7 +55,15 @@ estimate_R_cl_single <- function(
     # attach time index to incidence
     (\(x){dplyr::mutate(x, t = 1:nrow(x))})()
 
-  # estimate Rt
+  
+  # The RL deconvolution can be unstable at
+  # the start of the deconvoluted function,
+  # so we remove the first points based on 
+  # the mean of the kernels (this is heuristic):
+  incidence = filter(incidence,
+                     t > (dist.repdelay$mean + dist.incub$mean))
+  
+  # Estimate Rt
   res = incidence_to_R(
     incidence,
     generation.interval,

--- a/R/estimate_R_cl_single.R
+++ b/R/estimate_R_cl_single.R
@@ -60,7 +60,7 @@ estimate_R_cl_single <- function(
   # the start of the deconvoluted function,
   # so we remove the first points based on 
   # the mean of the kernels (this is heuristic):
-  incidence = filter(incidence,
+  incidence = dplyr::filter(incidence,
                      t > (dist.repdelay$mean + dist.incub$mean))
   
   # Estimate Rt


### PR DESCRIPTION
This fix is associated with high initial Rt values we observed especially with clinical data. 
@davidchampredon investigated and believed this problem is caused by the RL deconvolution algorithm that can be unstable at the start of the deconvoluted function. This fix left-censors the deconvoluted daily incidence (ie ignore the potential instabilities generated by RL deconvolution). The period censored is the sum of the means of the reporting delay and incubation distributions. This length is based on heuristics...  